### PR TITLE
Convert fake newlines in GITHUB_PRIVATE_KEY

### DIFF
--- a/octomachinery/github/config/app.py
+++ b/octomachinery/github/config/app.py
@@ -32,7 +32,7 @@ class GitHubAppIntegrationConfig:
     private_key = environ.var(
         None,
         name='GITHUB_PRIVATE_KEY',
-        converter=SecretStr,
+        converter=lambda s: SecretStr(s.replace('\\n', '\n')),
         validator=validate_is_not_none_if_app,
     )
     webhook_secret = environ.var(


### PR DESCRIPTION
Various tools (pipenv, systemd env vars) don't convert newlines and put them in verbatim. This transparently converts them to real newlines.