### PR TITLE
Only extract the needed token information

### DIFF
--- a/octomachinery/github/entities/app_installation.py
+++ b/octomachinery/github/entities/app_installation.py
@@ -53,11 +53,13 @@ class GitHubAppInstallation:
     async def retrieve_access_token(self):
         """Retrieve installation access token from GitHub API."""
         async with self._github_app.github_app_client as gh_api:
-            self._token = GitHubInstallationAccessToken(**(await gh_api.post(
+            result = await gh_api.post(
                 self._metadata.access_tokens_url,
                 data=b'',
                 accept='application/vnd.github.machine-man-preview+json',
-            )))
+            )
+            self._token = GitHubInstallationAccessToken(token=result['token'],
+                                                        expires_at=result['expires_at'])
         return self._token
 
     def get_github_api_client(


### PR DESCRIPTION
According to the [documentation][1] the result can contain:

* token
* expires_at
* permissions
* repositories

Currently it doesn't care about the additional attributes, but it is
making the application fail:
```python-traceback
    Traceback (most recent call last):
      File "/usr/local/lib/python3.7/asyncio/runners.py", line 43, in run
        return loop.run_until_complete(main)
      File "/usr/local/lib/python3.7/asyncio/base_events.py", line 584, in run_until_complete
        return future.result()
      File "/usr/local/lib/python3.7/site-packages/octomachinery/app/server/machinery.py", line 43, in run_forever
        async with GitHubApp(config.github) as github_app:
      File "/usr/local/lib/python3.7/site-packages/octomachinery/github/api/app_client.py", line 69, in __aenter__
        self._installations = await self.get_installations()
      File "/usr/local/lib/python3.7/site-packages/octomachinery/github/api/app_client.py", line 162, in get_installations
        await installations[install.id].retrieve_access_token()
      File "/usr/local/lib/python3.7/site-packages/octomachinery/github/entities/app_installation.py", line 49, in retrieve_access_token
        accept='application/vnd.github.machine-man-preview+json',
    TypeError: __init__() got an unexpected keyword argument 'permissions'
```
This started to show up when the application was made public and added
to another organization.

[1]: https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/