### PR TITLE
Fix pypi trove classifiers (Robot Framework)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,6 @@ classifiers =
     Environment :: Web Environment
 
     Framework :: AsyncIO
-    Framework :: Robot Framework
-    Framework :: Robot Framework :: Library
-    Framework :: Robot Framework :: Tool
 
     Intended Audience :: Developers
     Intended Audience :: Information Technology


### PR DESCRIPTION
The [PyPi trove classifiers set in setup.cfg](https://github.com/sanitizers/octomachinery/blob/master/setup.cfg#L30-L32) reference classifiers which are meant to be used for the [Robot Framework](https://pypi.org/project/robotframework/).