### PR TITLE
Add has_multiple_single_files + single_file_paths

### DIFF
--- a/octomachinery/github/models/__init__.py
+++ b/octomachinery/github/models/__init__.py
@@ -59,6 +59,9 @@ class GitHubAppInstallation:  # pylint: disable=too-few-public-methods
     suspended_at: typing.Optional[str]
     suspended_by: typing.Optional[str]
 
+    has_multiple_single_files: typing.Optional[bool]
+    single_file_paths: typing.List[str]
+
 
 @attr.dataclass
 class GitHubInstallationAccessToken:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
These undocumented options were added to GitHubAppInstallation and caused the application to error out. Adding these at least makes it start up again.