### PR TITLE
correct the return result based on new change of pyjwt

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -26,6 +26,7 @@ jobs:
         - TOXENV: build-docs
         - TOXENV: build-dists
         - TOXENV: python
+        - TOXENV: old-deps
 
     steps:
     - uses: actions/checkout@master

--- a/octomachinery/github/models/_compat.py
+++ b/octomachinery/github/models/_compat.py
@@ -1,0 +1,20 @@
+"""Compatibility shims for the models subpackage."""
+from functools import wraps as _wraps_function
+
+from jwt import encode as _compute_jwt
+try:
+    from jwt import __version__ as _pyjwt_version_str
+except ImportError:
+    _pyjwt_version_str = '0.0.0'
+
+
+_pyjwt_version_info = tuple(map(int, _pyjwt_version_str.split('.')))
+_is_pyjwt_above_v2_0 = _pyjwt_version_info >= (2, 0, 0)
+
+
+@_wraps_function(_compute_jwt)
+def _compute_jwt_below_v2_0(*args, **kwargs) -> str:
+    return _compute_jwt(*args, **kwargs).decode('utf-8')
+
+
+compute_jwt = _compute_jwt if _is_pyjwt_above_v2_0 else _compute_jwt_below_v2_0

--- a/octomachinery/github/models/private_key.py
+++ b/octomachinery/github/models/private_key.py
@@ -144,4 +144,4 @@ class GitHubPrivateKey:
             payload,
             key=self._rsa_private_key,
             algorithm='RS256',
-        ).decode('utf-8')
+        )

--- a/octomachinery/github/models/private_key.py
+++ b/octomachinery/github/models/private_key.py
@@ -6,7 +6,8 @@ from time import time
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
-from jwt import encode as compute_jwt
+
+from ._compat import compute_jwt
 
 
 def extract_private_key_sha1_fingerprint(rsa_private_key):

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ install_requires =
     environ-config >= 19.1.0
     envparse
     gidgethub >= 4.2.0
-    pyjwt[crypto]
+    pyjwt[crypto] >=2.0.0
     pyyaml
     sentry_sdk
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ install_requires =
     environ-config >= 19.1.0
     envparse
     gidgethub >= 4.2.0
-    pyjwt[crypto] >=2.0.0
+    pyjwt[crypto]
     pyyaml
     sentry_sdk
     setuptools_scm

--- a/tests/circular_imports_test.py
+++ b/tests/circular_imports_test.py
@@ -68,6 +68,23 @@ def test_no_warnings(import_path):
     imp_cmd = (
         sys.executable,
         '-W', 'error',
+
+        # NOTE: These are necessary for `tox -e old-deps`:
+        '-W', "ignore:Using or importing the ABCs from 'collections' instead "
+        "of from 'collections.abc' is deprecated since "
+        'Python 3.3, and in 3.10 it will stop working:'
+        'DeprecationWarning:jwt.api_jwt',
+        '-W', "ignore:Using or importing the ABCs from 'collections' instead "
+        "of from 'collections.abc' is deprecated since "
+        'Python 3.3, and in 3.9 it will stop working:'
+        'DeprecationWarning:jwt.api_jwt',
+        # NOTE: This looks like the line above but has a typo
+        # NOTE: (a whitespace is missing):
+        '-W', "ignore:Using or importing the ABCs from 'collections' instead "
+        "of from 'collections.abc' is deprecated since "
+        'Python 3.3,and in 3.9 it will stop working:'
+        'DeprecationWarning:jwt.api_jwt',
+
         '-W', 'ignore:"@coroutine" decorator is deprecated '
         'since Python 3.8, use "async def" instead:'
         'DeprecationWarning:aiohttp.helpers',

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,24 @@ commands =
     {envpython} -m pytest {posargs:--cov-report=term-missing:skip-covered}
 
 
+[testenv:old-deps]
+description =
+    Run tests with the lowest possible dependency versions as opposed to
+    using the latest ones
+commands_pre =
+    # NOTE: Not using `deps = ` for this because installing the dist
+    # NOTE: happens later and overrides it.
+    # NOTE: With this step we're setting certain packages to the lowest
+    # NOTE: versions — either limited by the runtime deps or just known
+    # NOTE: to work.
+    # NOTE: For example, PyJWT versions below 1.4.2 cause TypeError when
+    # NOTE: the PEM key is passed as bytes.
+    # Ref: https://github.com/sanitizers/octomachinery/issues/46:
+    {envpython} -m pip install 'gidgethub === 4.2.0' 'pyjwt === 1.4.2'
+setenv =
+    PYTEST_ADDOPTS = -W ignore:::jwt.api_jwt -W ignore:::jwt.algorithms
+
+
 [testenv:check-docs]
 basepython = python3
 isolated_build = true


### PR DESCRIPTION
correct the return result based on a new change of pyjwt
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

The pyjwt package is on version 2.x , in which the return type of encode is str. 
https://github.com/jpadilla/pyjwt/blob/f02fa0dc87bfa7bc471f3d6d3ca579d66e8f95e0/jwt/api_jwt.py#L44
which breaks the https://github.com/sanitizers/octomachinery/blob/94c3eaa7cc193aa537f0485fd580e26abd25fe26/octomachinery/github/models/private_key.py#L147

Fixes: #46 