### PR TITLE
Correct spelling in docs and docstrings

### DIFF
--- a/docs/howto-guides.rst
+++ b/docs/howto-guides.rst
@@ -7,7 +7,7 @@ Running a one-off task against GitHub API
 
 Sometimes you need to run a series of queries against GitHub API.
 To do this, initialize a token (it's taken from the ``GITHUB_TOKEN`` env
-var in the example below), constuct a GitHub API wrapper and you are
+var in the example below), construct a GitHub API wrapper and you are
 good to go.
 
 :py:class:`~octomachinery.github.api.raw_client.RawGitHubAPI` is a

--- a/octomachinery/app/routing/webhooks_dispatcher.py
+++ b/octomachinery/app/routing/webhooks_dispatcher.py
@@ -133,7 +133,7 @@ def webhook_request_to_event(wrapped_function):
 @validate_allowed_http_methods('POST')
 @webhook_request_to_event
 async def route_github_webhook_event(*, github_event, github_app):
-    """Dispatch incoming webhook events to corresponsing handlers."""
+    """Dispatch incoming webhook events to corresponding handlers."""
     asyncio.create_task(route_github_event(
         github_event=github_event,
         github_app=github_app,

--- a/octomachinery/github/api/app_client.py
+++ b/octomachinery/github/api/app_client.py
@@ -107,7 +107,7 @@ class GitHubApp:
     async def get_installation(self, event):
         """Retrieve an installation creds from store."""
         if 'installation' not in event.payload:
-            raise LookupError('This event occured outside of an installation')
+            raise LookupError('This event occurred outside of an installation')
 
         install_id = event.payload['installation']['id']
         return await self.get_installation_by_id(install_id)

--- a/octomachinery/routing/webhooks_dispatcher.py
+++ b/octomachinery/routing/webhooks_dispatcher.py
@@ -35,7 +35,7 @@ async def route_github_event(  # type: ignore[return]  # FIXME
         github_event: GitHubEvent,
         github_app: GitHubApp,
 ) -> Iterable[Any]:
-    """Dispatch GitHub event to corresponsing handlers.
+    """Dispatch GitHub event to corresponding handlers.
 
     Set up ``RUNTIME_CONTEXT`` before doing that. This is so
     the concrete event handlers have access to the API client
@@ -66,7 +66,7 @@ async def route_github_event(  # type: ignore[return]  # FIXME
             Some events (like `ping`) are
             happening application/GitHub-wide and are not bound to
             a specific installation. The webhook payloads of such events
-            don't contain any reference to an installaion.
+            don't contain any reference to an installation.
             Some events don't even refer to a GitHub App
             (e.g. `security_advisory`).
             """

--- a/octomachinery/utils/asynctools.py
+++ b/octomachinery/utils/asynctools.py
@@ -78,7 +78,7 @@ async def try_await(potentially_awaitable):
 
 
 async def amap(callback, async_iterable):
-    """Map asyncronous generator with a coroutine or a function."""
+    """Map asynchronous generator with a coroutine or a function."""
     async for async_value in async_iterable:
         yield await try_await(callback(async_value))
 

--- a/tests/app/action/runner_test.py
+++ b/tests/app/action/runner_test.py
@@ -17,7 +17,7 @@ from octomachinery.github.models.action_outcomes import ActionNeutral
 
 @process_event('unmatched_event', action='happened')
 async def unmatched_event_happened(action):  # pylint: disable=unused-argument
-    """Handle an unmached event."""
+    """Handle an unmatched event."""
 
 
 @process_event('check_run', action='created')

--- a/tests/utils/asynctools_test.py
+++ b/tests/utils/asynctools_test.py
@@ -11,7 +11,7 @@ def sync_power2(val):
 
 
 async def async_power2(val):
-    """Raise x to the power of 2 asyncronously."""
+    """Raise x to the power of 2 asynchronously."""
     return sync_power2(val)
 
 


### PR DESCRIPTION
The `codespell` linter found misspelled words in RST documents and docstrings in Python modules. This patch fixes all the typos found.