### PR TITLE
Update Read the Docs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,10 +5,11 @@ version: 2
 formats: all
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"
 
 python:
-  version: 3
   install:
   # - requirements: .docs-requirements.txt
   # - method: pip


### PR DESCRIPTION
Use `build.os` instead of `build.image` which is deprecated. See https://blog.readthedocs.com/use-build-os-config/